### PR TITLE
MID-973: 미디 채널 instrument의 속성으로 추가

### DIFF
--- a/miditoolkit/__init__.py
+++ b/miditoolkit/__init__.py
@@ -2,7 +2,7 @@
 Author: Wen-Yi Hsiao, Taiwan
 """
 
-__version__ = "1.1.3"
+__version__ = "1.2.0"
 
 # Convenience exports for commonly used classes.
 

--- a/miditoolkit/midi/parser.py
+++ b/miditoolkit/midi/parser.py
@@ -176,7 +176,7 @@ class MidiFile:
         track_name_map = collections.defaultdict(str)
 
         def __get_instrument(
-            program_: int,
+            program_: int | None,
             channel: int,
             track_: int,
             create_new: bool,
@@ -184,7 +184,6 @@ class MidiFile:
             """Gets the Instrument corresponding to the given program number,
             drum/non-drum type, channel, and track index.  If no such
             instrument exists, one is created.
-
             """
             # If we have already created an instrument for this program
             # number/track/channel, return it
@@ -196,7 +195,7 @@ class MidiFile:
                 return stragglers[(channel, track_)]
             # If we are told to, create a new instrument and store it
             if create_new:
-                instrument_ = Instrument(program_, track_name_map[track_idx])
+                instrument_ = Instrument(program_, track_name_map[track_idx], channel=channel)
                 # If any events appeared for this instrument before now,
                 # include them in the new instrument
                 if (channel, track_) in stragglers:
@@ -211,7 +210,7 @@ class MidiFile:
             # instrument
             else:
                 # Create a "straggler" instrument
-                instrument_ = Instrument(program_, track_name_map[track_idx])
+                instrument_ = Instrument(program_, track_name_map[track_idx], channel=channel)
                 # Note that stragglers ignores program number, because we want
                 # to store all events on a track which appear before the first
                 # note-on, regardless of program

--- a/miditoolkit/midi/parser.py
+++ b/miditoolkit/midi/parser.py
@@ -519,13 +519,14 @@ class MidiFile:
                         "program_change",
                         time=0,
                         program=instrument.program,
+                        channel=instrument.channel,
                     )
                 )
             # segment-related
             # Add all pitch bend events
             bend_list = []
             for bend in instrument.pitch_bends:
-                bend_list.append(mido.Message("pitchwheel", time=bend.time, pitch=bend.pitch))
+                bend_list.append(mido.Message("pitchwheel", time=bend.time, channel=instrument.channel, pitch=bend.pitch))
 
             # Add all control change events
             cc_list = []
@@ -535,6 +536,7 @@ class MidiFile:
                         mido.Message(
                             "control_change",
                             time=control_change.time,
+                            channel=instrument.channel,
                             control=control_change.number,
                             value=control_change.value,
                         )
@@ -546,6 +548,7 @@ class MidiFile:
                         mido.Message(
                             "control_change",
                             time=pedals.start,
+                            channel=instrument.channel,
                             control=64,
                             value=127,
                         )
@@ -555,6 +558,7 @@ class MidiFile:
                         mido.Message(
                             "control_change",
                             time=pedals.end,
+                            channel=instrument.channel,
                             control=64,
                             value=0,
                         )
@@ -579,6 +583,7 @@ class MidiFile:
                     mido.Message(
                         "note_on",
                         time=note.start,
+                        channel=instrument.channel,
                         note=note.pitch,
                         velocity=note.velocity,
                         end=note.end,
@@ -589,6 +594,7 @@ class MidiFile:
                     mido.Message(
                         "note_off",
                         time=note.end,
+                        channel=instrument.channel,
                         note=note.pitch,
                         velocity=note.velocity,
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "pozalabs-miditoolkit"
 packages = [{ include = "miditoolkit"}]
-version = "1.1.3"
+version = "1.2.0"
 description = "A python package for working with MIDI data files. (POZAlabs forked)"
 authors = ["pozalabs <contact@pozalabs.com>"]
 license = "MIT"


### PR DESCRIPTION
- 기존 miditoolkit 문제점: 
- channel을 사용자가 설정못하고 빈곳 찾아서 아무렇게나 넣음
- mido message에 program number를 무조건 밀어넣음
- 해결:
- channel을 Instrument 생성자의 인자로 하여 사용자가 설정하게 함
- program change 메세지를 조건부로 밀어넣음